### PR TITLE
reset mod_jog default values for mdx-20

### DIFF
--- a/outputs/mod_Roland_mill.js
+++ b/outputs/mod_Roland_mill.js
@@ -137,7 +137,7 @@ define(['require',
             findEl("mod_xhome").value = 0;
             findEl("mod_yhome").value = 152.4;
             findEl("mod_zhome").value = 60.5;
-            findEl("mod_jog").value = 60.5;
+            findEl("mod_jog").value = 2.0;
             }
          else {
             cmd = "mod_print.py /dev/usb/lp1 ';'";

--- a/templates/mod_roland_mill_controls.html
+++ b/templates/mod_roland_mill_controls.html
@@ -17,7 +17,7 @@
 <br><input type="button" id="mod_move_xyz" value="move to x0,y0,z0">
 {{/if }}
 <br>zjog (mm):
-&nbsp;<input type="text" id="mod_jog" size="3" value="60.5">
+&nbsp;<input type="text" id="mod_jog" size="3" value="2.0">
 {{#if show_move }}
 <br><input type="button" id="mod_move_xy" value="move to x0,y0,zjog">
 {{/if }}


### PR DESCRIPTION
The SRM-20 update made the z-jog default to 60.5mm for the MDX-20. A better default is 2mm.
